### PR TITLE
Properly check for ability to perform steps needing additional permissions

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,9 +12,28 @@ on:
         required: true
 
 jobs:
+  check-secrets:
+    name: Check for secrets
+    runs-on: ubuntu-22.04
+    outputs:
+      available: ${{ steps.check-secrets.outputs.available }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check
+        id: check-secrets
+        run: |
+          if [ "${{ secrets.AVAILABLE }}" != '' ]; then
+            echo "available=true" >> $GITHUB_OUTPUT;
+          else
+            echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+
   testing:
     name: Test
     runs-on: ubuntu-22.04
+    needs: check-secrets
     permissions:
       checks: write
       contents: read
@@ -48,7 +67,7 @@ jobs:
 
       - name: Report test results
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
-        if: ${{ !github.event.repository.fork && !cancelled() }}
+        if: ${{ needs.check-secrets.outputs.available == 'true' && !cancelled() }}
         with:
           name: Test Results
           path: "**/test-results.trx"


### PR DESCRIPTION
## 🎟️ Tracking

Testing given Codecov upload changes.

## 📔 Objective

Goes back to checking for secrets to skip a test upload step. Permissions checks and more have revealed that we simply cannot easily check for rights to perform this step without something like a GitHub secret check. Dirty, but it works.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
