### PR TITLE
Update _version workflow to use commit SHA made within a PR

### DIFF
--- a/.github/workflows/_version.yml
+++ b/.github/workflows/_version.yml
@@ -60,7 +60,8 @@ jobs:
           version_suffix=$patch_version
 
           if [[ "${{ inputs.is-release }}" == "false" ]]; then
-            version_suffix=$version_suffix-${GITHUB_SHA:0:7}
+            commit_sha=${{ github.event.pull_request.head.sha || github.sha }}
+            version_suffix=$version_suffix-${commit_sha:0:7}
           fi
 
           echo "  version: $base_version.$version_suffix"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Checks for `github.event.pull_request.head.sha` and uses that value if available. This fixes an issue where builds in a PR were using the merge commit of the PR, instead of the newest commit on the PR.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
