### PR TITLE
Convert Dockerfile to distroless base image

### DIFF
--- a/src/Billing/Dockerfile
+++ b/src/Billing/Dockerfile
@@ -1,25 +1,14 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.3-azurelinux3.0-distroless
 
 LABEL com.bitwarden.product="bitwarden"
+COPY --from=ghcr.io/alexaka1/distroless-dotnet-healthchecks:1 / /healthchecks
+HEALTHCHECK CMD ["/healthchecks/Distroless.HealthChecks", "--uri", "http://localhost:5000/alive"]
 
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-        curl=7.88.1* \
-    && rm -rf /var/lib/apt/lists/*
-
+USER app
 ENV ASPNETCORE_URLS http://+:5000
 WORKDIR /app
 EXPOSE 5000
 
-COPY prepare-env.sh /
-RUN chmod +x /prepare-env.sh && \
-    /prepare-env.sh
-
-# Enable healthcheck after implementing it in the service code
-# HEALTHCHECK CMD curl -f http://localhost:5000/alive || exit 1
-
 COPY obj/build-output/publish .
-
-USER bitwarden
 
 ENTRYPOINT ["dotnet", "/app/Billing.dll"]

--- a/src/Billing/Dockerfile
+++ b/src/Billing/Dockerfile
@@ -1,8 +1,6 @@
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.3-azurelinux3.0-distroless
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless
 
 LABEL com.bitwarden.product="bitwarden"
-COPY --from=ghcr.io/alexaka1/distroless-dotnet-healthchecks:1 / /healthchecks
-HEALTHCHECK CMD ["/healthchecks/Distroless.HealthChecks", "--uri", "http://localhost:5000/alive"]
 
 USER app
 ENV ASPNETCORE_URLS http://+:5000


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/VULN-234

## 📔 Objective

This is a first stab at converting some of our docker images to using a more-secure base image which runs rootless and distroless, reducing our attack surface.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
