### PR TITLE
[BRE-848] Add Workflow Permissions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -14,6 +14,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/_create-release-tag.yml
+++ b/.github/workflows/_create-release-tag.yml
@@ -19,6 +19,8 @@ jobs:
   release:
     name: Create release tag
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     env:
       _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
       _BOT_NAME: bitwarden-devops-bot

--- a/.github/workflows/_version.yml
+++ b/.github/workflows/_version.yml
@@ -12,6 +12,9 @@ on:
         description: "version to be built"
         value: ${{ jobs.version.outputs.version }}
 
+permissions:
+  contents: read
+
 jobs:
   version:
     name: Calculate version

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
   enforce-label:
     name: Enforce label


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-848](https://bitwarden.atlassian.net/browse/BRE-848)

## 📔 Objective

Adding permissions to all workflows not being updated by [BRE-831](https://bitwarden.atlassian.net/browse/BRE-831)
This will prepare for changing the org wide GitHub actions setting to `contents:read` and `packages:read` as the default permissions provided to workflows.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[BRE-848]: https://bitwarden.atlassian.net/browse/BRE-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRE-831]: https://bitwarden.atlassian.net/browse/BRE-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ