### PR TITLE
Refactor VUS, Duration for paypal controller load test

### DIFF
--- a/test/load/paypalcontroller.js
+++ b/test/load/paypalcontroller.js
@@ -11,7 +11,10 @@ export const options = {
       executor: "constant-vus",
       vus: __ENV.VUS ? parseInt(__ENV.VUS) : 1,
       duration: __ENV.DURATION ? __ENV.DURATION : "30s",
-      tags: { test_type: "single_user" },
+      tags: {
+        test_type: "single_user",
+        name: `${BILLING_RELAY_URL}/paypal/ipn/`,
+      },
     },
   },
   thresholds: {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
During testing, I found that `--vus` is incompatible with this specific scenario. I decided to move both VUS and duration to optional user provided values that can be passed with k6's `-e` argument.

This also cleans up the URl to shorten the path in DataDog.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/9bc439ff-e6a5-42e7-b968-da5e55c0f439)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
