### PR TITLE
[BRE-1871] Parallelizing the QA and Prod deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,21 +71,38 @@ jobs:
       push-docker-image: true
     secrets: inherit
 
-  deploy:
-    name: Trigger deployment via deploy repo
+  deploy-qa:
+    name: Trigger QA deployment via deploy repo
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
     needs:
       - tag
       - build-push-docker
-
     steps:
-      - name: Trigger deployment
+      - name: Trigger QA deployment
         uses: bitwarden/gh-actions/trigger-actions@main
         with:
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-          task: deploy-billing-relay
+          task: deploy-billing-relay-qa
+          data: '{"tag": "${{ needs.tag.outputs.git-tag }}"}'
+
+  deploy-prod:
+    name: Trigger prod deployment via deploy repo
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    needs:
+      - tag
+      - build-push-docker
+    steps:
+      - name: Trigger prod deployment
+        uses: bitwarden/gh-actions/trigger-actions@main
+        with:
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          task: deploy-billing-relay-prod
           data: '{"tag": "${{ needs.tag.outputs.git-tag }}"}'


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1871](https://bitwarden.atlassian.net/browse/BRE-1871)

## 📔 Objective

  - Splits the single deploy job in cd.yml into two parallel jobs: deploy-qa and deploy-prod
  - Each job fires its own task via trigger-actions (deploy-billing-relay-qa, deploy-billing-relay-prod)
  - Enables per-environment deployment monitoring end-to-end (one trigger = one deploy)

Related PRs:
  - https://github.com/bitwarden/deploy/pull/118
  - https://github.com/bitwarden/devops/pull/4680
  - https://github.com/bitwarden/billing-relay/pull/243
  - https://github.com/bitwarden/billing-pricing/pull/112
  - https://github.com/bitwarden/gh-actions/pull/765

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-1871]: https://bitwarden.atlassian.net/browse/BRE-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ